### PR TITLE
added creation dates to records

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rayon = "1.8.1"
 rfd = "0.13.0"
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.114"
-sqlx = { version = "0.7.3", features = ["sqlite", "runtime-tokio", "uuid"] }
+sqlx = { version = "0.7.3", features = ["sqlite", "runtime-tokio", "uuid", "chrono"] }
 tokio = { version = "1.36.0", features = ["full"] }
 uuid = { version = "1.7.0", features = ["v4", "v7", "serde"] }
 

--- a/src/apps.rs
+++ b/src/apps.rs
@@ -45,7 +45,7 @@ impl BreadApp {
         }
     }
 
-    pub fn apps_iter_mut(&mut self) -> impl Iterator<Item = (&str, Anchor, &mut dyn eframe::App)> {
+    fn apps_iter_mut(&mut self) -> impl Iterator<Item = (&str, Anchor, &mut dyn eframe::App)> {
         let vec = vec![
             (
                 "Visualizations",

--- a/src/apps/tableview.rs
+++ b/src/apps/tableview.rs
@@ -20,11 +20,13 @@ impl eframe::App for TableView {
                 ui.label("amount");
                 ui.label("time");
                 ui.label("tags");
+                ui.label("day added");
                 ui.end_row();
                 for (_, record) in self.records_communicator.view().iter() {
                     ui.label(format!("{}", record.amount()));
                     ui.label(format!("{}", record.datetime()));
                     ui.label(format!("{:?}", record.tags()));
+                    ui.label(format!("{}", record.created().date_naive()));
                     ui.end_row();
                 }
             });

--- a/src/apps/visualizations/bar_chart.rs
+++ b/src/apps/visualizations/bar_chart.rs
@@ -33,7 +33,6 @@ impl BarChartVis {
     }
 
     fn update_graphs(records: &HashMap<Uuid, ExpenseRecord>) -> (Vec<Bar>, Vec<Bar>) {
-        println!("{}", records.len());
         if records.is_empty() {
             return (vec![], vec![]);
         }


### PR DESCRIPTION
#8 By adding creation dates to records its easier to track when things have been created and if the standard changes in the future it will be easier to track what records need to change and which records do not.