### PR TITLE
improved number parsing

### DIFF
--- a/src/apps/visualizations/bar_chart.rs
+++ b/src/apps/visualizations/bar_chart.rs
@@ -30,7 +30,7 @@ impl BarChartVis {
             .has_changed()
             .expect("This Reciver should never return an error.")
         {
-            let (weekly, monthly) = Self::update_graphs(&self.values.borrow());
+            let (weekly, monthly) = Self::update_graphs(&self.values.borrow_and_update());
             self.weekly = weekly;
             self.monthly = monthly;
         }

--- a/src/model/profiles.rs
+++ b/src/model/profiles.rs
@@ -8,6 +8,14 @@ use sqlx::types::Uuid;
 
 use super::records::{ExpenseData, ExpenseRecord, ExpenseRecordBuilder};
 
+//IDEA: change to this if nessesary https://docs.rs/lexical/latest/lexical/
+fn to_num(str: &str) -> Result<f64, ProfileError> {
+    str.replace('.', "")
+        .replace(',', ".")
+        .parse::<f64>()
+        .or(Err(ProfileError::number(&str, "f64")))
+}
+
 #[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Income;
 impl Income {
@@ -15,11 +23,7 @@ impl Income {
         if str.is_empty() {
             return Ok(0);
         }
-        let str = str.replace(',', ".");
-        Ok((str
-            .parse::<f64>()
-            .or(Err(ProfileError::number(&str, "f64")))?
-            * 100.0) as usize)
+        Ok((to_num(str)? * 100.0) as usize)
     }
 }
 #[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -29,11 +33,7 @@ impl Expense {
         if str.is_empty() {
             return Ok(0);
         }
-        let str = str.replace(',', ".");
-        Ok((str
-            .parse::<f64>()
-            .or(Err(ProfileError::number(&str, "f64")))?
-            * -100.0) as usize)
+        Ok((to_num(str)? * -100.0) as usize)
     }
 }
 #[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -43,11 +43,7 @@ impl PosExpense {
         if str.is_empty() {
             return Ok(0);
         }
-        let str = str.replace(',', ".");
-        Ok((str
-            .parse::<f64>()
-            .or(Err(ProfileError::number(&str, "f64")))?
-            * 100.0) as usize)
+        Ok((to_num(str)? * 100.0) as usize)
     }
 }
 #[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -57,11 +53,7 @@ impl Movement {
         if str.is_empty() {
             return Ok(0);
         }
-        let str = str.replace(',', ".");
-        Ok((str
-            .parse::<f64>()
-            .or(Err(ProfileError::number(&str, "f64")))?
-            * 100.0) as isize)
+        Ok((to_num(str)? * 100.0) as isize)
     }
 }
 #[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize, Serialize)]


### PR DESCRIPTION
Since the parsing happens according to the american standard. I just made it so that the numbers would be parsed correctly by removeing any thousand separators. Also found a library that could be added if needed but didn't do so yet. https://docs.rs/lexical/latest/lexical/

Closes #30 