### PR TITLE
storage takes &mut self instead of &self

### DIFF
--- a/src/db/profiles.rs
+++ b/src/db/profiles.rs
@@ -42,7 +42,7 @@ impl GetKey<Uuid> for Profile {
 }
 
 impl Storage<Uuid, Profile> for DbProfiles {
-    fn get_all(&self) -> BoxFuture<'static, Response<Uuid, Profile>> {
+    fn get_all(&mut self) -> BoxFuture<'static, Response<Uuid, Profile>> {
         let pool = self.pool.clone();
         Box::pin(async move {
             let profiles = sqlx::query_as!(
@@ -60,7 +60,7 @@ impl Storage<Uuid, Profile> for DbProfiles {
             Response::ok(&action)
         })
     }
-    fn set(&self, value: Profile) -> BoxFuture<'static, Response<Uuid, Profile>> {
+    fn set(&mut self, value: Profile) -> BoxFuture<'static, Response<Uuid, Profile>> {
         let pool = self.pool.clone();
         Box::pin(async move {
             let profile = DbProfile::from_profile(&value);
@@ -75,7 +75,7 @@ impl Storage<Uuid, Profile> for DbProfiles {
             error_to_response(query_result, &ActionType::Set(value))
         })
     }
-    fn set_many(&self, values: Vec<Profile>) -> BoxFuture<'static, Response<Uuid, Profile>> {
+    fn set_many(&mut self, values: Vec<Profile>) -> BoxFuture<'static, Response<Uuid, Profile>> {
         let pool = self.pool.clone();
         Box::pin(async move {
             let profiles = values
@@ -99,7 +99,7 @@ impl Storage<Uuid, Profile> for DbProfiles {
             Response::from_result(query_result, &ActionType::SetMany(values))
         })
     }
-    fn update(&self, value: Profile) -> BoxFuture<'static, Response<Uuid, Profile>> {
+    fn update(&mut self, value: Profile) -> BoxFuture<'static, Response<Uuid, Profile>> {
         let pool = self.pool.clone();
         Box::pin(async move {
             let profile = DbProfile::from_profile(&value);
@@ -114,7 +114,7 @@ impl Storage<Uuid, Profile> for DbProfiles {
             Response::from_result(query_result, &ActionType::Update(value))
         })
     }
-    fn update_many(&self, values: Vec<Profile>) -> BoxFuture<'static, Response<Uuid, Profile>> {
+    fn update_many(&mut self, values: Vec<Profile>) -> BoxFuture<'static, Response<Uuid, Profile>> {
         let pool = self.pool.clone();
         Box::pin(async move {
             let profiles = values
@@ -138,7 +138,7 @@ impl Storage<Uuid, Profile> for DbProfiles {
             Response::from_result(query_result, &ActionType::SetMany(values))
         })
     }
-    fn delete(&self, key: Uuid) -> BoxFuture<'static, Response<Uuid, Profile>> {
+    fn delete(&mut self, key: Uuid) -> BoxFuture<'static, Response<Uuid, Profile>> {
         let pool = self.pool.clone();
         Box::pin(async move {
             let query_result = sqlx::query!("delete from profiles where uuid = ?", key)
@@ -147,7 +147,7 @@ impl Storage<Uuid, Profile> for DbProfiles {
             Response::from_result(query_result, &ActionType::Delete(key))
         })
     }
-    fn delete_many(&self, keys: Vec<Uuid>) -> BoxFuture<'static, Response<Uuid, Profile>> {
+    fn delete_many(&mut self, keys: Vec<Uuid>) -> BoxFuture<'static, Response<Uuid, Profile>> {
         let pool = self.pool.clone();
         Box::pin(async move {
             let query_result =
@@ -158,7 +158,7 @@ impl Storage<Uuid, Profile> for DbProfiles {
             Response::from_result(query_result, &ActionType::DeleteMany(keys))
         })
     }
-    fn setup(&self, drop: bool) -> BoxFuture<'static, Result<Vec<Profile>, ()>> {
+    fn setup(&mut self, drop: bool) -> BoxFuture<'static, Result<Vec<Profile>, ()>> {
         let pool = self.pool.clone();
         Box::pin(async move {
             if drop {

--- a/src/db/records.rs
+++ b/src/db/records.rs
@@ -223,7 +223,10 @@ impl Storage<Uuid, ExpenseRecord> for DbRecords {
             error_to_response(query_result, &ActionType::Delete(key))
         })
     }
-    fn delete_many(&mut self, keys: Vec<Uuid>) -> BoxFuture<'static, Response<Uuid, ExpenseRecord>> {
+    fn delete_many(
+        &mut self,
+        keys: Vec<Uuid>,
+    ) -> BoxFuture<'static, Response<Uuid, ExpenseRecord>> {
         let pool = self.pool.clone();
         Box::pin(async move {
             let query_result = utils::add_in_items(

--- a/src/db/records.rs
+++ b/src/db/records.rs
@@ -73,7 +73,7 @@ impl DbRecord {
 }
 
 impl Storage<Uuid, ExpenseRecord> for DbRecords {
-    fn get_all(&self) -> BoxFuture<'static, changer::Response<Uuid, ExpenseRecord>> {
+    fn get_all(&mut self) -> BoxFuture<'static, changer::Response<Uuid, ExpenseRecord>> {
         let pool = self.pool.clone();
         Box::pin(async move {
             let records = sqlx::query_as!(
@@ -104,7 +104,7 @@ impl Storage<Uuid, ExpenseRecord> for DbRecords {
         })
     }
     fn set(
-        &self,
+        &mut self,
         value: ExpenseRecord,
     ) -> BoxFuture<'static, changer::Response<Uuid, ExpenseRecord>> {
         let pool = self.pool.clone();
@@ -127,7 +127,7 @@ impl Storage<Uuid, ExpenseRecord> for DbRecords {
         })
     }
     fn set_many(
-        &self,
+        &mut self,
         values: Vec<ExpenseRecord>,
     ) -> BoxFuture<'static, Response<Uuid, ExpenseRecord>> {
         println!("setting many right now");
@@ -160,7 +160,7 @@ impl Storage<Uuid, ExpenseRecord> for DbRecords {
         })
     }
     fn update(
-        &self,
+        &mut self,
         value: ExpenseRecord,
     ) -> BoxFuture<'static, changer::Response<Uuid, ExpenseRecord>> {
         let pool = self.pool.clone();
@@ -183,7 +183,7 @@ impl Storage<Uuid, ExpenseRecord> for DbRecords {
         })
     }
     fn update_many(
-        &self,
+        &mut self,
         values: Vec<ExpenseRecord>,
     ) -> BoxFuture<'static, Response<Uuid, ExpenseRecord>> {
         let pool = self.pool.clone();
@@ -214,7 +214,7 @@ impl Storage<Uuid, ExpenseRecord> for DbRecords {
             Response::from_result(query_result, &ActionType::SetMany(values))
         })
     }
-    fn delete(&self, key: Uuid) -> BoxFuture<'static, changer::Response<Uuid, ExpenseRecord>> {
+    fn delete(&mut self, key: Uuid) -> BoxFuture<'static, changer::Response<Uuid, ExpenseRecord>> {
         let pool = self.pool.clone();
         Box::pin(async move {
             let query_result = sqlx::query!("delete from expense_records where uuid = ?", key)
@@ -223,7 +223,7 @@ impl Storage<Uuid, ExpenseRecord> for DbRecords {
             error_to_response(query_result, &ActionType::Delete(key))
         })
     }
-    fn delete_many(&self, keys: Vec<Uuid>) -> BoxFuture<'static, Response<Uuid, ExpenseRecord>> {
+    fn delete_many(&mut self, keys: Vec<Uuid>) -> BoxFuture<'static, Response<Uuid, ExpenseRecord>> {
         let pool = self.pool.clone();
         Box::pin(async move {
             let query_result = utils::add_in_items(
@@ -238,7 +238,7 @@ impl Storage<Uuid, ExpenseRecord> for DbRecords {
             Response::from_result(query_result, &ActionType::DeleteMany(keys))
         })
     }
-    fn setup(&self, drop: bool) -> BoxFuture<'static, Result<Vec<ExpenseRecord>, ()>> {
+    fn setup(&mut self, drop: bool) -> BoxFuture<'static, Result<Vec<ExpenseRecord>, ()>> {
         let pool = self.pool.clone();
         Box::pin(async move {
             if drop {


### PR DESCRIPTION
I did this for the future because the communicator is going to work with mutable references in the future to allow for owning the data structure yourself.