### PR TITLE
added origin

### DIFF
--- a/src/apps/profiles/create_profile.rs
+++ b/src/apps/profiles/create_profile.rs
@@ -210,7 +210,7 @@ start the timer. Check that the reciver is beeing set correctly.
                     datetime_col,
                     other_cols,
                     default_tags,
-                    origin_name
+                    origin_name,
                 },
             ..
         } = self;

--- a/src/apps/profiles/create_profile.rs
+++ b/src/apps/profiles/create_profile.rs
@@ -210,6 +210,7 @@ start the timer. Check that the reciver is beeing set correctly.
                     datetime_col,
                     other_cols,
                     default_tags,
+                    origin_name
                 },
             ..
         } = self;
@@ -268,6 +269,7 @@ start the timer. Check that the reciver is beeing set correctly.
                     Self::datetime_col_selection(ui, datetime_col);
                 });
             });
+            ui.add(egui::TextEdit::singleline(origin_name));
         });
         ui.add_space(10.);
         ui.separator();

--- a/src/apps/tableview.rs
+++ b/src/apps/tableview.rs
@@ -27,7 +27,7 @@ impl eframe::App for TableView {
                     ui.label(format!("{}", record.datetime()));
                     ui.label(format!("{:?}", record.tags()));
                     ui.label(format!("{}", record.created().date_naive()));
-                    ui.label(format!("{}", record.origin()));
+                    ui.label(record.origin().to_string());
                     ui.end_row();
                 }
             });

--- a/src/apps/tableview.rs
+++ b/src/apps/tableview.rs
@@ -20,12 +20,14 @@ impl eframe::App for TableView {
                 ui.label("time");
                 ui.label("tags");
                 ui.label("day added");
+                ui.label("origin");
                 ui.end_row();
                 for (_, record) in self.records_communicator.view().iter() {
                     ui.label(format!("{}", record.amount()));
                     ui.label(format!("{}", record.datetime()));
                     ui.label(format!("{:?}", record.tags()));
                     ui.label(format!("{}", record.created().date_naive()));
+                    ui.label(format!("{}", record.origin()));
                     ui.end_row();
                 }
             });

--- a/src/db/profiles.rs
+++ b/src/db/profiles.rs
@@ -5,10 +5,11 @@ use futures::future::BoxFuture;
 use sqlx::{types::Uuid, Pool, Sqlite};
 
 use crate::{
-    db::profiles, model::profiles::Profile, utils::{
+    model::profiles::Profile,
+    utils::{
         changer::{ActionType, Response},
         communicator::{GetKey, Storage},
-    }
+    },
 };
 
 use super::error_to_response;
@@ -27,7 +28,12 @@ struct DbProfile {
 impl DbProfile {
     pub fn from_profile(profile: &Profile) -> Self {
         let (uuid, name, origin_name, data) = profile.to_db();
-        Self { uuid, name, origin_name, data }
+        Self {
+            uuid,
+            name,
+            origin_name,
+            data,
+        }
     }
 
     pub fn into_profile(self) -> Profile {

--- a/src/db/records.rs
+++ b/src/db/records.rs
@@ -30,6 +30,7 @@ struct DbRecord {
     description: Option<String>,
     description_container: Vec<u8>,
     tags: String,
+    origin: String,
     data: Vec<u8>,
 }
 
@@ -49,6 +50,7 @@ impl DbRecord {
             description_container: bc::serialize(record.description_container()).unwrap(),
             tags: record.tags().clone().join(TAG_SEP),
             data: bc::serialize(record.data()).unwrap(),
+            origin: record.origin().clone(),
         }
     }
 
@@ -68,6 +70,7 @@ impl DbRecord {
                 .split(TAG_SEP)
                 .map(str::to_string)
                 .collect::<Vec<String>>(),
+            self.origin,
         )
     }
 }
@@ -87,6 +90,7 @@ impl Storage<Uuid, ExpenseRecord> for DbRecords {
                     description,
                     description_container,
                     tags,
+                    origin,
                     data
                 from
                     expense_records
@@ -111,7 +115,9 @@ impl Storage<Uuid, ExpenseRecord> for DbRecords {
         Box::pin(async move {
             let record = DbRecord::from_record(&value);
             let query_result = sqlx::query!(
-                "insert into expense_records values(?, ?, ?, ?, ?, ?, ?, ?)",
+                r#"insert into expense_records(
+                    datetime_created, uuid, amount, datetime, description, description_container, tags, origin, data
+                ) values(?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
                 record.datetime_created,
                 record.uuid,
                 record.amount,
@@ -119,7 +125,8 @@ impl Storage<Uuid, ExpenseRecord> for DbRecords {
                 record.description,
                 record.description_container,
                 record.tags,
-                record.data
+                record.origin,
+                record.data,
             )
             .execute(&*pool)
             .await;
@@ -139,7 +146,7 @@ impl Storage<Uuid, ExpenseRecord> for DbRecords {
                 pool,
                 "insert into expense_records(
                     datetime_created, uuid, amount, datetime, description, 
-                    description_container, tags, data
+                    description_container, tags, origin, data
                 )",
                 records,
                 |mut builder, value| {
@@ -151,6 +158,7 @@ impl Storage<Uuid, ExpenseRecord> for DbRecords {
                         .push_bind(value.description)
                         .push_bind(value.description_container)
                         .push_bind(value.tags)
+                        .push_bind(value.origin)
                         .push_bind(value.data);
                 },
             )
@@ -167,7 +175,9 @@ impl Storage<Uuid, ExpenseRecord> for DbRecords {
         Box::pin(async move {
             let record = DbRecord::from_record(&value);
             let query_result = sqlx::query!(
-                "insert into expense_records values(?, ?, ?, ?, ?, ?, ?, ?)",
+                r#"insert into expense_records(
+                    datetime_created, uuid, amount, datetime, description, description_container, tags, origin, data
+                ) values(?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
                 record.datetime_created,
                 record.uuid,
                 record.amount,
@@ -175,7 +185,8 @@ impl Storage<Uuid, ExpenseRecord> for DbRecords {
                 record.description,
                 record.description_container,
                 record.tags,
-                record.data
+                record.origin,
+                record.data,
             )
             .execute(&*pool)
             .await;
@@ -194,7 +205,7 @@ impl Storage<Uuid, ExpenseRecord> for DbRecords {
                 pool,
                 "insert into expense_records(
                     datetime_created, uuid, amount, datetime, description, 
-                    description_container, tags, data
+                    description_container, tags, origin, data
                 )",
                 records,
                 |mut builder, value| {
@@ -206,6 +217,7 @@ impl Storage<Uuid, ExpenseRecord> for DbRecords {
                         .push_bind(value.description)
                         .push_bind(value.description_container)
                         .push_bind(value.tags)
+                        .push_bind(value.origin)
                         .push_bind(value.data);
                 },
             )
@@ -261,6 +273,7 @@ impl Storage<Uuid, ExpenseRecord> for DbRecords {
                     description text,
                     description_container blob not null,
                     tags text not null,
+                    origin text not null,
                     data blob not null
                 );
                 "#
@@ -280,6 +293,7 @@ impl Storage<Uuid, ExpenseRecord> for DbRecords {
                     description,
                     description_container,
                     tags,
+                    origin,
                     data
                 from
                     expense_records

--- a/src/model/profiles.rs
+++ b/src/model/profiles.rs
@@ -6,8 +6,6 @@ use chrono::{DateTime, Local, NaiveDate, NaiveDateTime, NaiveTime};
 use serde::{Deserialize, Serialize};
 use sqlx::types::Uuid;
 
-use crate::db::profiles;
-
 use super::records::{ExpenseData, ExpenseRecord, ExpenseRecordBuilder};
 
 //IDEA: change to this if nessesary https://docs.rs/lexical/latest/lexical/
@@ -124,7 +122,7 @@ impl Profile {
         margins: (usize, usize),
         delimiter: char,
         mut default_tags: Vec<String>,
-        origin_name: String
+        origin_name: String,
     ) -> Self {
         let uuid = Uuid::new_v4();
         let mut positions = other_data.iter().map(|(pos, _)| *pos).collect::<Vec<_>>();
@@ -248,9 +246,7 @@ impl Profile {
         )
     }
 
-    pub fn from_db(
-        uuid: Uuid, name: String, origin_name: String, data: &[u8]
-    ) -> Self {
+    pub fn from_db(uuid: Uuid, name: String, origin_name: String, data: &[u8]) -> Self {
         let (
             margins, delimiter, amount, datetime, other_data, profile_width, default_tags
         ): DbProfileParts = bc::deserialize(data).unwrap();
@@ -265,7 +261,7 @@ impl Profile {
             other_data,
             width: profile_width,
             default_tags,
-            origin_name
+            origin_name,
         }
     }
 }
@@ -444,18 +440,23 @@ impl ProfileBuilder {
             self.delimiter,
             self.origin_name,
         ) {
-            (Some(name), Some(expense_col), Some(datetime_col), Some(margins), Some(delimiter), Some(origin_name)) => {
-                Ok(Profile::new(
-                    name,
-                    expense_col,
-                    datetime_col,
-                    self.other_cols,
-                    margins,
-                    delimiter,
-                    self.default_tags,
-                    origin_name,
-                ))
-            }
+            (
+                Some(name),
+                Some(expense_col),
+                Some(datetime_col),
+                Some(margins),
+                Some(delimiter),
+                Some(origin_name),
+            ) => Ok(Profile::new(
+                name,
+                expense_col,
+                datetime_col,
+                self.other_cols,
+                margins,
+                delimiter,
+                self.default_tags,
+                origin_name,
+            )),
             _ => Err(()),
         }
     }
@@ -565,7 +566,7 @@ impl IntermediateProfileState {
                 .map(|(a, b)| (*a, b.clone()))
                 .collect(),
             default_tags: profile.default_tags.clone(),
-            origin_name: profile.origin_name.clone()
+            origin_name: profile.origin_name.clone(),
         }
     }
 }

--- a/src/model/profiles.rs
+++ b/src/model/profiles.rs
@@ -6,6 +6,8 @@ use chrono::{DateTime, Local, NaiveDate, NaiveDateTime, NaiveTime};
 use serde::{Deserialize, Serialize};
 use sqlx::types::Uuid;
 
+use crate::db::profiles;
+
 use super::records::{ExpenseData, ExpenseRecord, ExpenseRecordBuilder};
 
 //IDEA: change to this if nessesary https://docs.rs/lexical/latest/lexical/
@@ -100,6 +102,7 @@ pub struct Profile {
     other_data: HashMap<usize, ParsableWrapper>,
     pub width: usize,
     pub default_tags: Vec<String>,
+    pub origin_name: String,
 }
 
 type DbProfileParts = (
@@ -121,6 +124,7 @@ impl Profile {
         margins: (usize, usize),
         delimiter: char,
         mut default_tags: Vec<String>,
+        origin_name: String
     ) -> Self {
         let uuid = Uuid::new_v4();
         let mut positions = other_data.iter().map(|(pos, _)| *pos).collect::<Vec<_>>();
@@ -142,6 +146,7 @@ impl Profile {
             other_data,
             width: profile_width,
             default_tags,
+            origin_name,
         }
     }
     pub fn parse_file(&self, file: &str) -> Result<Vec<ExpenseRecord>, ProfileError> {
@@ -210,6 +215,7 @@ impl Profile {
             }
         }
         builder.default_tags(self.default_tags.clone());
+        builder.origin(self.origin_name.clone());
         builder.build()
     }
 
@@ -224,10 +230,11 @@ impl Profile {
         rows
     }
 
-    pub fn to_db(&self) -> (Uuid, String, Vec<u8>) {
+    pub fn to_db(&self) -> (Uuid, String, String, Vec<u8>) {
         (
             self.uuid,
             self.name.clone(),
+            self.origin_name.clone(),
             bc::serialize(&(
                 self.margins,
                 self.delimiter,
@@ -241,7 +248,9 @@ impl Profile {
         )
     }
 
-    pub fn from_db(uuid: Uuid, name: String, data: &[u8]) -> Self {
+    pub fn from_db(
+        uuid: Uuid, name: String, origin_name: String, data: &[u8]
+    ) -> Self {
         let (
             margins, delimiter, amount, datetime, other_data, profile_width, default_tags
         ): DbProfileParts = bc::deserialize(data).unwrap();
@@ -256,6 +265,7 @@ impl Profile {
             other_data,
             width: profile_width,
             default_tags,
+            origin_name
         }
     }
 }
@@ -380,6 +390,7 @@ pub struct ProfileBuilder {
     margins: Option<(usize, usize)>,
     delimiter: Option<char>,
     default_tags: Vec<String>,
+    origin_name: Option<String>,
 }
 
 impl ProfileBuilder {
@@ -421,6 +432,9 @@ impl ProfileBuilder {
         self.default_tags = default_tags;
         self
     }
+    pub fn origin_name(&mut self, origin_name: String) {
+        self.origin_name = Some(origin_name);
+    }
     pub fn build(self) -> Result<Profile, ()> {
         match (
             self.name,
@@ -428,8 +442,9 @@ impl ProfileBuilder {
             self.datetime_col,
             self.margins,
             self.delimiter,
+            self.origin_name,
         ) {
-            (Some(name), Some(expense_col), Some(datetime_col), Some(margins), Some(delimiter)) => {
+            (Some(name), Some(expense_col), Some(datetime_col), Some(margins), Some(delimiter), Some(origin_name)) => {
                 Ok(Profile::new(
                     name,
                     expense_col,
@@ -438,6 +453,7 @@ impl ProfileBuilder {
                     margins,
                     delimiter,
                     self.default_tags,
+                    origin_name,
                 ))
             }
             _ => Err(()),
@@ -457,6 +473,10 @@ impl ProfileBuilder {
         let mut builder = Self::default()
             .name(state.name.clone())
             .margins(state.margin_top, state.margin_btm);
+
+        if !state.origin_name.is_empty() {
+            builder.origin_name(state.origin_name.clone());
+        }
 
         if let Some(delimiter) = state.delimiter.chars().collect::<Vec<_>>().first() {
             builder = builder.delimiter(*delimiter);
@@ -527,6 +547,7 @@ pub struct IntermediateProfileState {
     pub datetime_col: Option<DateTimeColumn>,
     pub other_cols: Vec<(usize, ParsableWrapper)>,
     pub default_tags: Vec<String>,
+    pub origin_name: String,
 }
 
 impl IntermediateProfileState {
@@ -544,6 +565,7 @@ impl IntermediateProfileState {
                 .map(|(a, b)| (*a, b.clone()))
                 .collect(),
             default_tags: profile.default_tags.clone(),
+            origin_name: profile.origin_name.clone()
         }
     }
 }

--- a/src/model/records.rs
+++ b/src/model/records.rs
@@ -50,7 +50,7 @@ impl ExpenseRecord {
             description: None,
             data,
             tags: default_tags,
-            origin
+            origin,
         }
     }
 
@@ -161,7 +161,7 @@ impl ExpenseRecordBuilder {
                 datetime,
                 self.data.clone(),
                 self.default_tags.clone(),
-                self.origin.clone()
+                self.origin.clone(),
             )),
             _ => Err(ProfileError::build(self.amount, self.datetime)),
         }

--- a/src/model/records.rs
+++ b/src/model/records.rs
@@ -31,6 +31,7 @@ pub struct ExpenseRecord {
     description: Option<DescriptionContainer>,
     data: Vec<ExpenseData>,
     tags: Vec<String>,
+    origin: String,
 }
 
 impl ExpenseRecord {
@@ -39,6 +40,7 @@ impl ExpenseRecord {
         datetime: DateTime<Local>,
         data: Vec<ExpenseData>,
         default_tags: Vec<String>,
+        origin: String,
     ) -> Self {
         Self {
             datetime_created: Local::now(),
@@ -48,6 +50,7 @@ impl ExpenseRecord {
             description: None,
             data,
             tags: default_tags,
+            origin
         }
     }
 
@@ -59,6 +62,7 @@ impl ExpenseRecord {
         description: Option<DescriptionContainer>,
         data: Vec<ExpenseData>,
         tags: Vec<String>,
+        origin: String,
     ) -> Self {
         Self {
             datetime_created,
@@ -68,6 +72,7 @@ impl ExpenseRecord {
             description,
             data,
             tags,
+            origin,
         }
     }
     pub fn created(&self) -> &DateTime<Local> {
@@ -94,6 +99,9 @@ impl ExpenseRecord {
     pub fn tags(&self) -> &Vec<String> {
         &self.tags
     }
+    pub fn origin(&self) -> &String {
+        &self.origin
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -114,6 +122,7 @@ pub struct ExpenseRecordBuilder {
     datetime: Option<DateTime<Local>>,
     data: Vec<ExpenseData>,
     default_tags: Vec<String>,
+    origin: String,
 }
 
 impl ExpenseRecordBuilder {
@@ -141,6 +150,9 @@ impl ExpenseRecordBuilder {
     pub fn default_tags(&mut self, tags: Vec<String>) {
         self.default_tags = tags;
     }
+    pub fn origin(&mut self, origin: String) {
+        self.origin = origin;
+    }
     pub fn build(&self) -> Result<ExpenseRecord, ProfileError> {
         println!("{:?}, {:?}", self.amount, self.datetime);
         match (self.amount, self.datetime) {
@@ -149,6 +161,7 @@ impl ExpenseRecordBuilder {
                 datetime,
                 self.data.clone(),
                 self.default_tags.clone(),
+                self.origin.clone()
             )),
             _ => Err(ProfileError::build(self.amount, self.datetime)),
         }


### PR DESCRIPTION
Every record now has a origin string that determines where that payment came from but not which profile exactly it came from. Multiple profiles can have the same origin which allows for different inputs from the same source.

This is a step towards being able to connect records as the same transaction (#35) as well as checking for duplicate records (#27) from the same origin

Closes #33 