### PR TITLE
#48 sort filter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ chrono = { version = "0.4.38", features = ["serde"] }
 eframe = "0.29.1"
 egui = "0.29.1"
 egui_dock = "0.14.0"
-egui_extras = "0.29.1"
+egui_extras = { version = "0.29.1", features = ["chrono"] }
 egui_plot = "0.29.0"
 env_logger = "0.11.5"
 flowync = "5.1.0"

--- a/src/apps/linking.rs
+++ b/src/apps/linking.rs
@@ -8,10 +8,9 @@ use egui::{
     SidePanel, Ui, UiBuilder, Widget,
 };
 use egui_light_states::{
-    default_promise_await::DefaultCreatePromiseAwait, future_await::FutureAwait, UiStates,
+    future_await::FutureAwait, UiStates,
 };
-use lazy_async_promise::{BoxedSendError, ImmediateValuePromise};
-use tracing::info;
+use lazy_async_promise::ImmediateValuePromise;
 use uuid::Uuid;
 
 use crate::{

--- a/src/apps/tableview.rs
+++ b/src/apps/tableview.rs
@@ -1,9 +1,10 @@
 use data_communicator::buffered::{communicator::Communicator, query::QueryType};
 use eframe::App;
-use egui::Ui;
+use egui::{Frame, Label, RichText, Sense, Ui, UiBuilder, Widget};
+use tracing::info;
 use uuid::Uuid;
 
-use crate::model::records::ExpenseRecord;
+use crate::{components::soft_button::soft_button, model::records::ExpenseRecord};
 
 pub struct TableView {
     records: Communicator<Uuid, ExpenseRecord>,
@@ -31,13 +32,28 @@ impl App for TableView {
                         ui.label("datetime created");
                     }
                     if self.show_datetime() {
-                        ui.label("datetime");
+                        let response = soft_button("datetime_sorting", "datetime", ui);
+                        if response.double_clicked() {
+                            self.records.sort(|a, b| b.datetime().cmp(a.datetime()));
+                        } else if response.clicked() {
+                            self.records.sort(|a, b| a.datetime().cmp(b.datetime()));
+                        } 
                     }
                     if self.show_uuid() {
-                        ui.label("uuid");
+                        let response = soft_button("uuid_sorting", "uuid", ui);
+                        if response.double_clicked() {
+                            self.records.sort(|a, b| b.uuid().cmp(a.uuid()));
+                        } else if response.clicked() {
+                            self.records.sort(|a, b| a.uuid().cmp(b.uuid()));
+                        } 
                     }
                     if self.show_amount() {
-                        ui.label("amount");
+                        let response = soft_button("amount_sorting", "amount", ui);
+                        if response.double_clicked() {
+                            self.records.sort(|a, b| b.amount().cmp(a.amount()));
+                        } else if response.clicked() {
+                            self.records.sort(|a, b| a.amount().cmp(b.amount()));
+                        } 
                     }
                     if self.show_description() {
                         ui.label("description");
@@ -46,10 +62,15 @@ impl App for TableView {
                         ui.label("tags");
                     }
                     if self.show_origin() {
-                        ui.label("origin");
+                        let response = soft_button("origin_sorting", "origin", ui);
+                        if response.double_clicked() {
+                            self.records.sort(|a, b| b.origin().cmp(a.origin()));
+                        } else if response.clicked() {
+                            self.records.sort(|a, b| a.origin().cmp(b.origin()));
+                        } 
                     }
                     ui.end_row();
-                    for record in self.records.data_iter() {
+                    for record in self.records.data_sorted() {
                         if self.show_datetime_created() {
                             ui.label(format!("{}", record.created().date_naive()));
                         }
@@ -154,9 +175,9 @@ impl Default for ColumnToggles {
             uuid: false,
             amount: true,
             description: true,
-            tags: false,
+            tags: true,
             datetime: true,
-            origin: false,
+            origin: true,
         }
     }
 }

--- a/src/apps/tableview.rs
+++ b/src/apps/tableview.rs
@@ -1,101 +1,58 @@
+mod filterstate;
+mod tablecolumns;
+
 use data_communicator::buffered::{communicator::Communicator, query::QueryType};
 use eframe::App;
-use egui::{Frame, Label, RichText, Sense, Ui, UiBuilder, Widget};
-use tracing::info;
+use egui::{CentralPanel, SidePanel};
+use filterstate::FilterState;
+use tablecolumns::TableColumns;
 use uuid::Uuid;
 
-use crate::{components::soft_button::soft_button, model::records::ExpenseRecord};
+use crate::model::records::ExpenseRecord;
 
 pub struct TableView {
     records: Communicator<Uuid, ExpenseRecord>,
-    column_toggles: ColumnToggles,
+    columns_info: TableColumns,
+    filter_state: FilterState,
 }
 
 impl App for TableView {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         self.records.state_update();
 
-        egui::CentralPanel::default().show(ctx, |ui| {
-            ui.horizontal(|ui| {
-                ui.label("table view");
-                if ui.button("delete all").clicked() {
-                    self.delete_all();
-                }
-                ui.label(format!("Curretly {} records.", self.records.data().len()));
-            });
+        CentralPanel::default().show(ctx, |ui| {
+            CentralPanel::default().show_inside(ui, |ui| {
+                ui.horizontal(|ui| {
+                    ui.label("table view");
+                    if ui.button("delete all").clicked() {
+                        self.delete_all();
+                    }
+                    ui.label(format!("Curretly {} records.", self.records.data().len()));
+                });
 
-            self.column_toggles(ui);
+                self.columns_info.toggles(ui);
 
-            egui::ScrollArea::both().show(ui, |ui| {
-                egui::Grid::new("table of records").show(ui, |ui| {
-                    if self.show_datetime_created() {
-                        ui.label("datetime created");
-                    }
-                    if self.show_datetime() {
-                        let response = soft_button("datetime_sorting", "datetime", ui);
-                        if response.double_clicked() {
-                            self.records.sort(|a, b| b.datetime().cmp(a.datetime()));
-                        } else if response.clicked() {
-                            self.records.sort(|a, b| a.datetime().cmp(b.datetime()));
-                        } 
-                    }
-                    if self.show_uuid() {
-                        let response = soft_button("uuid_sorting", "uuid", ui);
-                        if response.double_clicked() {
-                            self.records.sort(|a, b| b.uuid().cmp(a.uuid()));
-                        } else if response.clicked() {
-                            self.records.sort(|a, b| a.uuid().cmp(b.uuid()));
-                        } 
-                    }
-                    if self.show_amount() {
-                        let response = soft_button("amount_sorting", "amount", ui);
-                        if response.double_clicked() {
-                            self.records.sort(|a, b| b.amount().cmp(a.amount()));
-                        } else if response.clicked() {
-                            self.records.sort(|a, b| a.amount().cmp(b.amount()));
-                        } 
-                    }
-                    if self.show_description() {
-                        ui.label("description");
-                    }
-                    if self.show_tags() {
-                        ui.label("tags");
-                    }
-                    if self.show_origin() {
-                        let response = soft_button("origin_sorting", "origin", ui);
-                        if response.double_clicked() {
-                            self.records.sort(|a, b| b.origin().cmp(a.origin()));
-                        } else if response.clicked() {
-                            self.records.sort(|a, b| a.origin().cmp(b.origin()));
-                        } 
-                    }
-                    ui.end_row();
-                    for record in self.records.data_sorted() {
-                        if self.show_datetime_created() {
-                            ui.label(format!("{}", record.created().date_naive()));
-                        }
-                        if self.show_datetime() {
-                            ui.label(format!("{}", record.datetime().date_naive()));
-                        }
-                        if self.show_uuid() {
-                            ui.label(format!("{}", record.uuid().0));
-                        }
-                        if self.show_amount() {
-                            ui.label(record.formatted_amount());
-                        }
-                        if self.show_description() {
-                            ui.label(format!("{:?}", record.description()));
-                        }
-                        if self.show_tags() {
-                            ui.label(format!("{:?}", record.tags()));
-                        }
-                        if self.show_origin() {
-                            ui.label(record.origin().to_string());
-                        }
+                egui::ScrollArea::both().show(ui, |ui| {
+                    egui::Grid::new("table of records").show(ui, |ui| {
+                        self.columns_info.header(&mut self.records, ui);
                         ui.end_row();
-                    }
+
+                        for record in self
+                            .records
+                            .data_sorted_iter()
+                            .filter(|r| self.filter_state.filter(r))
+                        {
+                            self.columns_info.row(record, ui);
+                            ui.end_row();
+                        }
+                    });
                 });
             });
+            SidePanel::right("filter_selection")
+                .resizable(true)
+                .show_inside(ui, |ui| {
+                    self.filter_state.display_filters(ui);
+                });
         });
     }
 }
@@ -108,7 +65,8 @@ impl TableView {
             let _ = records.query_future(QueryType::All).await;
             Self {
                 records,
-                column_toggles: ColumnToggles::default(),
+                columns_info: TableColumns::default(),
+                filter_state: FilterState::default(),
             }
         }
     }
@@ -119,79 +77,5 @@ impl TableView {
     pub fn delete_all(&mut self) {
         let keys = self.records.data_map().keys().cloned().collect::<Vec<_>>();
         self.records.delete_many(keys);
-    }
-
-    fn column_toggles(&mut self, ui: &mut Ui) {
-        ui.horizontal_wrapped(|ui| {
-            for (label, boolean) in self.column_toggles.toggles() {
-                ui.horizontal_wrapped(|ui| ui.checkbox(boolean, label));
-            }
-        });
-    }
-
-    fn show_datetime_created(&self) -> bool {
-        self.column_toggles.datetime_created
-    }
-
-    fn show_uuid(&self) -> bool {
-        self.column_toggles.uuid
-    }
-
-    fn show_amount(&self) -> bool {
-        self.column_toggles.amount
-    }
-
-    fn show_description(&self) -> bool {
-        self.column_toggles.description
-    }
-
-    fn show_tags(&self) -> bool {
-        self.column_toggles.tags
-    }
-
-    fn show_datetime(&self) -> bool {
-        self.column_toggles.datetime
-    }
-
-    fn show_origin(&self) -> bool {
-        self.column_toggles.origin
-    }
-}
-
-struct ColumnToggles {
-    datetime_created: bool,
-    uuid: bool,
-    amount: bool,
-    description: bool,
-    tags: bool,
-    datetime: bool,
-    origin: bool,
-}
-
-impl Default for ColumnToggles {
-    fn default() -> Self {
-        Self {
-            datetime_created: false,
-            uuid: false,
-            amount: true,
-            description: true,
-            tags: true,
-            datetime: true,
-            origin: true,
-        }
-    }
-}
-
-impl ColumnToggles {
-    fn toggles(&mut self) -> [(&str, &mut bool); 7] {
-        [
-            ("datetime created", &mut self.datetime_created),
-            ("uuid", &mut self.uuid),
-            ("amount", &mut self.amount),
-            ("description", &mut self.description),
-            ("tags", &mut self.tags),
-            ("datetime", &mut self.datetime),
-            ("origin", &mut self.origin),
-        ]
     }
 }

--- a/src/apps/tableview/filterstate.rs
+++ b/src/apps/tableview/filterstate.rs
@@ -1,0 +1,106 @@
+mod amount;
+mod date;
+mod uuid;
+mod tags;
+mod origin;
+
+use std::sync::Arc;
+
+use amount::AmountFilter;
+use date::DateFilter;
+use egui::Ui;
+use origin::OriginFilter;
+use tags::TagsFilter;
+use uuid::UuidFilter;
+
+use crate::model::records::ExpenseRecord;
+
+pub(super) struct FilterState {
+    filter: Arc<dyn Fn(&ExpenseRecord) -> bool + Send + Sync>,
+    filters: Vec<Box<dyn TableFilter + Send + 'static>>,
+}
+
+impl Default for FilterState {
+    fn default() -> Self {
+        Self {
+            filter: Arc::new(|_| true),
+            filters: vec![
+                UuidFilter::default().into(),
+                AmountFilter::default().into(),
+                DateFilter::default().into(),
+                TagsFilter::default().into(),
+                OriginFilter::default().into(),
+            ],
+        }
+    }
+}
+
+impl FilterState {
+    pub(super) fn filter(&self, record: &ExpenseRecord) -> bool {
+        (self.filter)(record)
+    }
+
+    fn set_filter(&mut self) {
+        let filters = self
+            .filters
+            .iter()
+            .filter_map(|filter| filter.filter())
+            .collect::<Vec<_>>();
+
+        if filters.is_empty() {
+            self.filter = Arc::new(|_| true);
+        } else {
+            self.filter = Arc::new(move |r| filters.iter().all(|filter| filter(r)));
+        }
+    }
+
+    pub(super) fn display_filters(&mut self, ui: &mut Ui) {
+        if ui.button("apply filter").clicked() {
+            self.set_filter();
+        }
+        ui.separator();
+        for filter in self.filters.iter_mut() {
+            filter.ui(ui);
+            ui.add_space(5.)
+        }
+    }
+}
+
+fn box_dyn(func: impl Fn(&ExpenseRecord) -> bool + Send + Sync + 'static) -> DataFilter {
+    Box::new(func) as DataFilter
+}
+
+type DataFilter = Box<dyn Fn(&ExpenseRecord) -> bool + Send + Sync + 'static>;
+
+impl<T> From<T> for Box<dyn TableFilter + Send + 'static>
+where
+    T: TableFilter + Send + 'static,
+{
+    fn from(value: T) -> Self {
+        Box::new(value) as Box<dyn TableFilter + Send + 'static>
+    }
+}
+
+pub trait TableFilter {
+    fn ui(&mut self, ui: &mut Ui) {
+        ui.group(|ui| {
+            ui.label(self.name());
+            ui.horizontal(|ui| {
+                if self.active() {
+                    self.display(ui);
+                    if ui.button("clear").clicked() {
+                        self.deactivate();
+                    }
+                } else {
+                    self.filter_activation(ui);
+                }
+            });
+        });
+    }
+    fn name(&self) -> &str;
+    fn active(&self) -> bool;
+    fn deactivate(&mut self);
+    fn display(&mut self, ui: &mut Ui);
+    fn filter(&self) -> Option<DataFilter>;
+    fn filter_activation(&mut self, ui: &mut Ui);
+}

--- a/src/apps/tableview/filterstate/amount.rs
+++ b/src/apps/tableview/filterstate/amount.rs
@@ -1,0 +1,83 @@
+use egui::Ui;
+
+use crate::model::records::ExpenseRecord;
+
+use super::{box_dyn, DataFilter, TableFilter};
+
+pub struct AmountFilter(Option<AmountFilterType>);
+
+impl Default for AmountFilter {
+    fn default() -> Self {
+        Self(None)
+    }
+}
+
+#[derive(Clone)]
+enum AmountFilterType {
+    Precise(f64),
+    Between(f64, f64),
+}
+impl AmountFilterType {
+    fn default_precise() -> Self {
+        Self::Precise(0.)
+    }
+    fn default_between() -> Self {
+        Self::Between(0., 0.)
+    }
+}
+
+impl TableFilter for AmountFilter {
+    fn name(&self) -> &str {
+        "Amount"
+    }
+    fn active(&self) -> bool {
+        self.0.is_some()
+    }
+    fn deactivate(&mut self) {
+        self.0 = None;
+    }
+    fn display(&mut self, ui: &mut Ui) {
+        if let Some(amount_filter) = &mut self.0 {
+            match amount_filter {
+                AmountFilterType::Precise(amount) => {
+                    ui.add(egui::DragValue::new(amount).max_decimals(2));
+                }
+                AmountFilterType::Between(lower, upper) => {
+                    ui.label("lower");
+                    ui.add(egui::DragValue::new(lower).max_decimals(2));
+                    ui.label("upper");
+                    ui.add(egui::DragValue::new(upper).max_decimals(2));
+                }
+            }
+        }
+    }
+    fn filter(&self) -> Option<DataFilter> {
+        self.0.as_ref().map(|amount_filter| {
+            match amount_filter {
+                AmountFilterType::Precise(amount) => {
+                    let amount = to_isize(*amount);
+                    box_dyn(move |record: &ExpenseRecord| record.amount().eq(&amount))
+                }
+                AmountFilterType::Between(lower, upper) => {
+                    let lower = to_isize(*lower);
+                    let upper = to_isize(*upper);
+                    box_dyn(move |record: &ExpenseRecord| {
+                        lower <= *record.amount() && record.amount() <= &upper
+                    })
+                }
+            }
+        })
+    }
+    fn filter_activation(&mut self, ui: &mut Ui) {
+        if ui.button("precise").clicked() {
+            self.0 = Some(AmountFilterType::default_precise());
+        }
+        if ui.button("between").clicked() {
+            self.0 = Some(AmountFilterType::default_between());
+        }
+    }
+}
+
+fn to_isize(amount: f64) -> isize {
+    (amount * 100.) as isize
+}

--- a/src/apps/tableview/filterstate/date.rs
+++ b/src/apps/tableview/filterstate/date.rs
@@ -1,0 +1,78 @@
+use chrono::NaiveDate;
+use egui::Ui;
+use egui_extras::DatePickerButton;
+
+use crate::model::records::ExpenseRecord;
+
+use super::{box_dyn, DataFilter, TableFilter};
+
+pub struct DateFilter(Option<DateFilterType>);
+
+impl Default for DateFilter {
+    fn default() -> Self {
+        Self(None)
+    }
+}
+
+#[derive(Clone)]
+enum DateFilterType {
+    Precise(NaiveDate),
+    Between(NaiveDate, NaiveDate),
+}
+
+impl DateFilterType {
+    fn default_precise() -> Self {
+        Self::Precise(NaiveDate::default())
+    }
+    fn default_between() -> Self {
+        Self::Between(NaiveDate::default(), NaiveDate::default())
+    }
+}
+
+impl TableFilter for DateFilter {
+    fn name(&self) -> &str {
+        "Date"
+    }
+    fn active(&self) -> bool {
+        self.0.is_some()
+    }
+    fn deactivate(&mut self) {
+        self.0 = None;
+    }
+    fn display(&mut self, ui: &mut Ui) {
+        if let Some(date_filter) = &mut self.0 {
+            match date_filter {
+                DateFilterType::Precise(date) => {
+                    ui.add(DatePickerButton::new(date).id_salt("date_filter_precise"));
+                }
+                DateFilterType::Between(lower, upper) => {
+                    ui.label("lower");
+                    ui.add(DatePickerButton::new(lower).id_salt("date_filter_between_lower"));
+                    ui.label("upper");
+                    ui.add(DatePickerButton::new(upper).id_salt("date_filter_between_upper"));
+                }
+            }
+        }
+    }
+    fn filter(&self) -> Option<DataFilter> {
+        self.0.as_ref().map(|date_filter| {
+            match date_filter.clone() {
+                DateFilterType::Precise(date) => {
+                    box_dyn(move |record: &ExpenseRecord| record.datetime().date_naive().eq(&date))
+                }
+                DateFilterType::Between(lower, upper) => box_dyn(move |record: &ExpenseRecord| {
+                    record.datetime().date_naive() >= lower && record.datetime().date_naive() <= upper
+                }),
+            }
+        })
+    }
+    fn filter_activation(&mut self, ui: &mut Ui) {
+        if ui.button("precise").clicked() {
+            self.0 = Some(DateFilterType::default_precise());
+        }
+        if ui.button("between").clicked() {
+            self.0 = Some(DateFilterType::default_between());
+        }
+    }
+    
+}

--- a/src/apps/tableview/filterstate/origin.rs
+++ b/src/apps/tableview/filterstate/origin.rs
@@ -1,0 +1,40 @@
+use egui::TextEdit;
+
+use crate::model::records::ExpenseRecord;
+
+use super::{box_dyn, TableFilter};
+
+
+
+#[derive(Default)]
+pub struct OriginFilter(Option<String>);
+
+impl TableFilter for OriginFilter {
+    fn name(&self) -> &str {
+        "Origin"
+    }
+    fn active(&self) -> bool {
+        self.0.is_some()
+    }
+    fn deactivate(&mut self) {
+        self.0 = None;
+    }
+    fn display(&mut self, ui: &mut egui::Ui) {
+        if let Some(origin_filter) = &mut self.0 {
+            ui.add(TextEdit::singleline(origin_filter));
+        }
+    }
+    fn filter(&self) -> Option<super::DataFilter> {
+        self.0.as_ref().map(|origin_filter| {
+            let origin = origin_filter.clone();
+            box_dyn(move |record: &ExpenseRecord| record.origin().contains(&origin))
+        })
+    }
+    fn filter_activation(&mut self, ui: &mut egui::Ui) {
+        if ui.button("origin").clicked() {
+            self.0 = Some(String::default());
+        }
+    }
+
+}
+

--- a/src/apps/tableview/filterstate/tags.rs
+++ b/src/apps/tableview/filterstate/tags.rs
@@ -1,0 +1,43 @@
+use egui::TextEdit;
+
+use crate::model::records::ExpenseRecord;
+
+use super::{box_dyn, TableFilter};
+
+#[derive(Default)]
+pub struct TagsFilter(Option<String>);
+
+impl TableFilter for TagsFilter {
+    fn name(&self) -> &str {
+        "Tags"
+    }
+    fn active(&self) -> bool {
+        self.0.is_some()
+    }
+    fn deactivate(&mut self) {
+        self.0 = None;
+    }
+    fn display(&mut self, ui: &mut egui::Ui) {
+        if let Some(tags_filter) = &mut self.0 {
+            ui.add(TextEdit::singleline(tags_filter));
+        }
+    }
+    fn filter(&self) -> Option<super::DataFilter> {
+        self.0.as_ref().map(|tags_filter| {
+            let tags = tags_filter.clone();
+            box_dyn(move |record: &ExpenseRecord| {
+                for tag in record.tags() {
+                    if tag.contains(&tags) {
+                        return true;
+                    }
+                }
+                false
+            })
+        })
+    }
+    fn filter_activation(&mut self, ui: &mut egui::Ui) {
+        if ui.button("tags").clicked() {
+            self.0 = Some(String::default());
+        }
+    }
+}

--- a/src/apps/tableview/filterstate/uuid.rs
+++ b/src/apps/tableview/filterstate/uuid.rs
@@ -1,0 +1,42 @@
+use egui::{TextEdit, Ui};
+
+use crate::model::records::ExpenseRecord;
+
+use super::{box_dyn, DataFilter, TableFilter};
+
+#[derive(Default)]
+pub struct UuidFilter(Option<String>);
+
+impl From<String> for UuidFilter {
+    fn from(value: String) -> Self {
+        Self(Some(value))
+    }
+}
+
+impl TableFilter for UuidFilter {
+    fn name(&self) -> &str {
+        "Uuid"
+    }
+    fn active(&self) -> bool {
+        self.0.is_some()
+    }
+    fn deactivate(&mut self) {
+        self.0 = None;
+    }
+    fn display(&mut self, ui: &mut Ui) {
+        if let Some(uuid_filter) = &mut self.0 {
+            ui.add(TextEdit::singleline(uuid_filter));
+        }
+    }
+    fn filter(&self) -> Option<DataFilter> {
+        self.0.as_ref().map(|uuid_filter| {
+            let uuid = uuid_filter.clone();
+            box_dyn(move |record: &ExpenseRecord| record.uuid().to_string().eq(&uuid))
+        })
+    }
+    fn filter_activation(&mut self, ui: &mut Ui) {
+        if ui.button("uuid").clicked() {
+            self.0 = String::default().into();
+        }
+    }
+}

--- a/src/apps/tableview/tablecolumns.rs
+++ b/src/apps/tableview/tablecolumns.rs
@@ -1,0 +1,176 @@
+use chrono::{DateTime, Local};
+use data_communicator::buffered::communicator::Communicator;
+use egui::Ui;
+use uuid::Uuid;
+
+use crate::{components::soft_button::soft_button, model::records::ExpenseRecord};
+
+pub(super) struct TableColumns {
+    datetime_created: TableColumn<DateTime<Local>>,
+    uuid: TableColumn<Uuid>,
+    amount: TableColumn<isize>,
+    description: TableColumn<String>,
+    tags: TableColumn<Vec<String>>,
+    datetime: TableColumn<DateTime<Local>>,
+    origin: TableColumn<String>,
+}
+
+impl TableColumns {
+    pub(super) fn toggles(&mut self, ui: &mut Ui) {
+        ui.horizontal(|ui| {
+            self.datetime_created.toggle(ui);
+            self.datetime.toggle(ui);
+            self.uuid.toggle(ui);
+            self.amount.toggle(ui);
+            self.description.toggle(ui);
+            self.tags.toggle(ui);
+            self.origin.toggle(ui);
+        });
+    }
+    pub(super) fn header(&self, records: &mut Communicator<Uuid, ExpenseRecord>, ui: &mut Ui) {
+        self.datetime_created.display_header(records, ui);
+        self.datetime.display_header(records, ui);
+        self.uuid.display_header(records, ui);
+        self.amount.display_header(records, ui);
+        self.description.display_header(records, ui);
+        self.tags.display_header(records, ui);
+        self.origin.display_header(records, ui);
+    }
+    pub(super) fn row(&self, record: &ExpenseRecord, ui: &mut Ui) {
+        self.datetime_created.display_value(record, ui);
+        self.datetime.display_value(record, ui);
+        self.uuid.display_value(record, ui);
+        self.amount.display_value(record, ui);
+        self.description.display_value(record, ui);
+        self.tags.display_value(record, ui);
+        self.description.display_value(record, ui);
+        self.origin.display_value(record, ui);
+    }
+}
+
+impl Default for TableColumns {
+    fn default() -> Self {
+        Self {
+            datetime_created: TableColumn::inactive("datetime created", d_created),
+            uuid: TableColumn::active("uuid", d_uuid).extract_fn(uuid),
+            amount: TableColumn::active("amount", d_amount).extract_fn(amount),
+            description: TableColumn::active("description", d_description),
+            tags: TableColumn::active("tags", d_tags),
+            datetime: TableColumn::active("datetime", d_datetime).extract_fn(datetime),
+            origin: TableColumn::active("origin", d_origin).extract_fn(origin),
+        }
+    }
+}
+
+struct TableColumn<T> {
+    name: &'static str,
+    active: bool,
+    search_value: Option<T>,
+    extract_fn: Option<fn(&ExpenseRecord) -> &T>,
+    display: fn(&ExpenseRecord, &mut Ui),
+}
+
+impl<T> TableColumn<T>
+where
+    T: Ord + 'static,
+{
+    fn active(name: &'static str, display: fn(&ExpenseRecord, &mut Ui)) -> Self {
+        Self {
+            name,
+            active: true,
+            search_value: None,
+            extract_fn: None,
+            display,
+        }
+    }
+
+    fn inactive(name: &'static str, display: fn(&ExpenseRecord, &mut Ui)) -> Self {
+        Self {
+            name,
+            active: false,
+            search_value: None,
+            extract_fn: None,
+            display,
+        }
+    }
+
+    fn extract_fn(mut self, func: fn(&ExpenseRecord) -> &T) -> Self {
+        self.extract_fn = Some(func);
+        self
+    }
+
+    fn toggle(&mut self, ui: &mut Ui) {
+        ui.checkbox(&mut self.active, self.name);
+    }
+
+    fn display_header(&self, records: &mut Communicator<Uuid, ExpenseRecord>, ui: &mut Ui) {
+        if !self.active {
+            return;
+        }
+
+        if let Some(extract_fn) = self.extract_fn {
+            let response = soft_button(format!("{}_sorting", self.name), self.name, ui);
+            if response.double_clicked() {
+                records.sort(move |a, b| extract_fn(b).cmp(extract_fn(a)));
+            } else if response.clicked() {
+                records.sort(move |a, b| extract_fn(a).cmp(extract_fn(b)));
+            }
+            if let Some(size) = response.intrinsic_size {
+                ui.set_width(size.x);
+            }
+        } else {
+            ui.label(self.name);
+        }
+    }
+
+    fn display_value(&self, record: &ExpenseRecord, ui: &mut Ui) {
+        if !self.active {
+            return;
+        }
+        (self.display)(record, ui);
+    }
+}
+
+fn d_created(record: &ExpenseRecord, ui: &mut Ui) {
+    ui.label(format!("{}", record.created().date_naive()));
+}
+
+fn datetime(record: &ExpenseRecord) -> &DateTime<Local> {
+    record.datetime()
+}
+
+fn d_datetime(record: &ExpenseRecord, ui: &mut Ui) {
+    ui.label(format!("{}", record.datetime().date_naive()));
+}
+
+fn uuid(record: &ExpenseRecord) -> &Uuid {
+    record.uuid()
+}
+
+fn d_uuid(record: &ExpenseRecord, ui: &mut Ui) {
+    ui.label(format!("{}", record.uuid().0));
+}
+
+fn amount(record: &ExpenseRecord) -> &isize {
+    record.amount()
+}
+
+fn d_amount(record: &ExpenseRecord, ui: &mut Ui) {
+    ui.label(record.formatted_amount());
+}
+
+fn d_description(record: &ExpenseRecord, ui: &mut Ui) {
+    ui.label(format!("{:?}", record.description()));
+}
+
+fn d_tags(record: &ExpenseRecord, ui: &mut Ui) {
+    ui.label(format!("{:?}", record.tags()));
+}
+
+fn origin(record: &ExpenseRecord) -> &String {
+    record.origin()
+}
+
+fn d_origin(record: &ExpenseRecord, ui: &mut Ui) {
+    ui.label(record.origin().to_string());
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,3 +1,4 @@
 pub mod expense_record;
 pub mod option_display;
+pub mod soft_button;
 

--- a/src/components/soft_button.rs
+++ b/src/components/soft_button.rs
@@ -1,0 +1,32 @@
+use std::hash::Hash;
+
+use egui::{Frame, Label, Response, RichText, Ui, UiBuilder, Widget};
+
+pub fn soft_button(
+    id_salt: impl Hash,
+    text: impl Into<String>,
+    ui: &mut Ui,
+    ) -> Response {
+    ui.scope_builder(
+        UiBuilder::new()
+            .id_salt(id_salt)
+            .sense(egui::Sense::click()),
+        |ui| {
+            let response = ui.response();
+            let visuals = ui.style().interact(&response);
+            let text_color = visuals.text_color();
+
+            Frame::canvas(ui.style())
+                .fill(visuals.bg_fill.gamma_multiply(0.3))
+                .stroke(visuals.bg_stroke)
+                .show(ui, |ui| {
+                    ui.vertical_centered(|ui| {
+                        Label::new(RichText::new(text).color(text_color))
+                            .selectable(false)
+                            .ui(ui);
+                    });
+                });
+        },
+    )
+    .response
+}

--- a/src/model/records.rs
+++ b/src/model/records.rs
@@ -99,7 +99,7 @@ impl ExpenseRecord {
         self.amount as f64 / 100.
     }
     pub fn formatted_amount(&self) -> String {
-        format!("{}", self.amount as f32 / 100.0)
+        format!("{:.2}€", self.amount as f32 / 100.0)
     }
     pub fn datetime(&self) -> &DateTime<Local> {
         &self.datetime


### PR DESCRIPTION
The table view now has two new features: Sorting and Filtering.

### Sorting
This is done very easily by pressing on the table header once to sort in one way on that column and twice to sort the other way on that column.

### Filtering
In a new Menu on the side you can now add and remove filters with a few different options, mainly filtering for a specific value or for a range of values between a and b. All of this has been made in a extremely extensible way, where you could easily add new filters for specific columns or add filtering on columns on which cannot be filtered as of now.



Closes #48 